### PR TITLE
feat: add sample Detroit neighborhood GeoJSON boundary file

### DIFF
--- a/data/sample/detroit/neighborhoods.geojson
+++ b/data/sample/detroit/neighborhoods.geojson
@@ -1,0 +1,86 @@
+{
+  "type": "FeatureCollection",
+  "name": "detroit_neighborhoods",
+  "crs": {
+    "type": "name",
+    "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" }
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "neighborhood": "West Pullman",
+        "geometry_id": "west_pullman",
+        "population": 24000,
+        "note": "approximate bounding box for sample use only"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-83.180, 42.320],
+          [-83.140, 42.320],
+          [-83.140, 42.295],
+          [-83.180, 42.295],
+          [-83.180, 42.320]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "neighborhood": "Englewood",
+        "geometry_id": "englewood",
+        "population": 30000,
+        "note": "approximate bounding box for sample use only"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-83.120, 42.375],
+          [-83.085, 42.375],
+          [-83.085, 42.355],
+          [-83.120, 42.355],
+          [-83.120, 42.375]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "neighborhood": "Midtown",
+        "geometry_id": "midtown",
+        "population": 18000,
+        "note": "approximate bounding box for sample use only"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-83.065, 42.355],
+          [-83.040, 42.355],
+          [-83.040, 42.340],
+          [-83.065, 42.340],
+          [-83.065, 42.355]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "neighborhood": "Lincoln Park",
+        "geometry_id": "lincoln_park",
+        "population": 38000,
+        "note": "approximate bounding box for sample use only"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-83.180, 42.250],
+          [-83.140, 42.250],
+          [-83.140, 42.220],
+          [-83.180, 42.220],
+          [-83.180, 42.250]
+        ]]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #1

Adds data/sample/detroit/neighborhoods.geojson with approximate bounding
boxes for the four neighborhoods used in the sample analysis: West Pullman,
Englewood, Midtown, and Lincoln Park.

Each feature includes a note field explicitly flagging the coordinates as
approximate placeholders. For production use, replace with official boundaries
from data.detroitmi.gov.