### PR TITLE
feat: add San Juan, Puerto Rico as third sample city

### DIFF
--- a/data/cities/registry.yaml
+++ b/data/cities/registry.yaml
@@ -89,3 +89,43 @@ cities:
         pct_elderly: 18.0
         pct_no_ac: 4.0
         population: 78000
+
+  san_juan:
+    name: San Juan
+    country: Puerto Rico
+    region: Metropolitan Area
+    coordinate_system: wgs84
+    geojson: data/sample/san_juan/neighborhoods.geojson
+    neighborhoods:
+      - id: santurce
+        name: Santurce
+        lst_mean: 38.5
+        lst_p90: 42.0
+        tree_cover_pct: 8.0
+        pct_elderly: 16.0
+        pct_no_ac: 18.0
+        population: 60000
+      - id: hato_rey
+        name: Hato Rey
+        lst_mean: 40.2
+        lst_p90: 44.1
+        tree_cover_pct: 5.0
+        pct_elderly: 13.0
+        pct_no_ac: 15.0
+        population: 48000
+      - id: rio_piedras
+        name: Rio Piedras
+        lst_mean: 36.8
+        lst_p90: 40.5
+        tree_cover_pct: 18.0
+        pct_elderly: 19.0
+        pct_no_ac: 22.0
+        population: 75000
+      - id: old_san_juan
+        name: Old San Juan
+        lst_mean: 34.5
+        lst_p90: 37.8
+        tree_cover_pct: 12.0
+        pct_elderly: 22.0
+        pct_no_ac: 8.0
+        population: 3000

--- a/data/sample/san_juan/neighborhoods.geojson
+++ b/data/sample/san_juan/neighborhoods.geojson
@@ -1,0 +1,86 @@
+{
+  "type": "FeatureCollection",
+  "name": "san_juan_neighborhoods",
+  "crs": {
+    "type": "name",
+    "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" }
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "neighborhood": "Santurce",
+        "geometry_id": "santurce",
+        "population": 60000,
+        "note": "approximate bounding box for sample use only"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-66.075, 18.450],
+          [-66.040, 18.450],
+          [-66.040, 18.430],
+          [-66.075, 18.430],
+          [-66.075, 18.450]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "neighborhood": "Hato Rey",
+        "geometry_id": "hato_rey",
+        "population": 48000,
+        "note": "approximate bounding box for sample use only"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-66.080, 18.425],
+          [-66.050, 18.425],
+          [-66.050, 18.405],
+          [-66.080, 18.405],
+          [-66.080, 18.425]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "neighborhood": "Rio Piedras",
+        "geometry_id": "rio_piedras",
+        "population": 75000,
+        "note": "approximate bounding box for sample use only"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-66.110, 18.400],
+          [-66.070, 18.400],
+          [-66.070, 18.375],
+          [-66.110, 18.375],
+          [-66.110, 18.400]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "neighborhood": "Old San Juan",
+        "geometry_id": "old_san_juan",
+        "population": 3000,
+        "note": "approximate bounding box for sample use only"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-66.120, 18.470],
+          [-66.105, 18.470],
+          [-66.105, 18.455],
+          [-66.120, 18.455],
+          [-66.120, 18.470]
+        ]]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds San Juan, Puerto Rico as the third sample city in HeatWatch, expanding geographic coverage to the Caribbean.

## Changes
- Added `data/sample/san_juan/neighborhoods.geojson` with neighborhood boundary data
- Registered `san_juan` in the city registry with 4 neighborhoods:
  - Santurce
  - Hato Rey
  - Rio Piedras
  - Old San Juan

## Why San Juan
San Juan is a high-priority urban heat island candidate given its dense urban fabric, tropical climate, and limited tree canopy in several neighborhoods. It also broadens the dataset beyond the continental US.

## Testing
- [ ] GeoJSON renders correctly on map
- [ ] City registry loads San Juan without errors
- [ ] All 4 neighborhoods appear in the neighborhood selector