### PR TITLE
fix(geo_utils): correct clip_array_to_bounds off-by-one; add geo_utils tests + NDVI no-data guard

### DIFF
--- a/src/analysis/map_export.py
+++ b/src/analysis/map_export.py
@@ -5,6 +5,9 @@ from pathlib import Path
 
 import numpy as np
 
+# Color used for pixels with no valid NDVI value (NaN / no-data).
+NODATA_COLOR = "#999999"
+
 # NDVI color legend breakpoints and their corresponding colors
 # Based on standard remote sensing classification
 NDVI_LEGEND = [
@@ -24,8 +27,13 @@ def ndvi_to_color(value: float) -> str:
         value: NDVI value in range [-1, 1].
 
     Returns:
-        Hex color string (e.g. '#91cf60').
+        Hex color string (e.g. '#91cf60'). NaN / no-data values return
+        NODATA_COLOR rather than being misclassified as dense vegetation.
     """
+    # NaN compares False against every breakpoint, so guard it explicitly;
+    # otherwise no-data pixels fall through to the dense-canopy color.
+    if value != value:
+        return NODATA_COLOR
     for entry in NDVI_LEGEND:
         if entry["min"] <= value < entry["max"]:
             return entry["color"]
@@ -102,7 +110,7 @@ def export_ndvi_map(
         grid_html += "<tr>"
         for c in range(cols):
             val = float(ndvi[r, c])
-            color = "#999999" if np.isnan(val) else ndvi_to_color(val)
+            color = NODATA_COLOR if np.isnan(val) else ndvi_to_color(val)
             grid_html += (
                 f'<td style="background:{color};width:{cell_size}px;'
                 f'height:{cell_size}px;" title="NDVI={val:.3f}"></td>'

--- a/src/utils/geo_utils.py
+++ b/src/utils/geo_utils.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 import numpy as np
 
+# Tolerance for floating-point error when converting a geographic offset into an
+# integer pixel index (see clip_array_to_bounds). Far smaller than one pixel,
+# large enough to absorb IEEE-754 rounding of products like 0.8 * 10.
+_PIXEL_EPS = 1e-9
+
 
 def bounds_to_bbox(
     min_lon: float, min_lat: float, max_lon: float, max_lat: float
@@ -97,10 +102,17 @@ def clip_array_to_bounds(
     lon_range = array_bounds["max_lon"] - array_bounds["min_lon"]
     lat_range = array_bounds["max_lat"] - array_bounds["min_lat"]
 
-    col_start = int((clip_bounds["min_lon"] - array_bounds["min_lon"]) / lon_range * cols)
-    col_end = int((clip_bounds["max_lon"] - array_bounds["min_lon"]) / lon_range * cols)
-    row_start = int((array_bounds["max_lat"] - clip_bounds["max_lat"]) / lat_range * rows)
-    row_end = int((array_bounds["max_lat"] - clip_bounds["min_lat"]) / lat_range * rows)
+    # Snap to the nearest pixel within a small tolerance before truncating.
+    # Plain int() truncation turns a mathematically-integer index that floating
+    # point stores as e.g. 7.999999999 into 7, shifting the clip window by a
+    # whole pixel. _PIXEL_EPS absorbs that representation error.
+    def _index(value: float) -> int:
+        return int(value + _PIXEL_EPS)
+
+    col_start = _index((clip_bounds["min_lon"] - array_bounds["min_lon"]) / lon_range * cols)
+    col_end = _index((clip_bounds["max_lon"] - array_bounds["min_lon"]) / lon_range * cols)
+    row_start = _index((array_bounds["max_lat"] - clip_bounds["max_lat"]) / lat_range * rows)
+    row_end = _index((array_bounds["max_lat"] - clip_bounds["min_lat"]) / lat_range * rows)
 
     col_start = max(0, col_start)
     col_end = min(cols, col_end)

--- a/tests/test_geo_utils.py
+++ b/tests/test_geo_utils.py
@@ -1,0 +1,112 @@
+import numpy as np
+import pytest
+
+from src.utils.geo_utils import (
+    bounds_to_bbox,
+    clip_array_to_bounds,
+    haversine_distance,
+    pixel_to_coords,
+)
+
+
+# --- bounds_to_bbox ---------------------------------------------------------
+
+def test_bounds_to_bbox_returns_named_dict():
+    bbox = bounds_to_bbox(-100.0, 40.0, -99.0, 41.0)
+    assert bbox == {
+        "min_lon": -100.0,
+        "min_lat": 40.0,
+        "max_lon": -99.0,
+        "max_lat": 41.0,
+    }
+
+
+def test_bounds_to_bbox_rejects_inverted_longitude():
+    with pytest.raises(ValueError):
+        bounds_to_bbox(-99.0, 40.0, -100.0, 41.0)
+
+
+def test_bounds_to_bbox_rejects_inverted_latitude():
+    with pytest.raises(ValueError):
+        bounds_to_bbox(-100.0, 41.0, -99.0, 40.0)
+
+
+def test_bounds_to_bbox_rejects_degenerate_extent():
+    # Equal bounds have zero extent and must be rejected.
+    with pytest.raises(ValueError):
+        bounds_to_bbox(-100.0, 40.0, -100.0, 41.0)
+
+
+# --- pixel_to_coords --------------------------------------------------------
+
+def test_pixel_to_coords_origin():
+    # GDAL affine: (x_origin, pixel_width, row_rot, y_origin, col_rot, pixel_height)
+    transform = (-100.0, 0.01, 0.0, 41.0, 0.0, -0.01)
+    lon, lat = pixel_to_coords(0, 0, transform)
+    assert lon == pytest.approx(-100.0)
+    assert lat == pytest.approx(41.0)
+
+
+def test_pixel_to_coords_offset():
+    transform = (-100.0, 0.01, 0.0, 41.0, 0.0, -0.01)
+    lon, lat = pixel_to_coords(10, 20, transform)
+    # col moves east by 20 * 0.01, row moves south by 10 * 0.01.
+    assert lon == pytest.approx(-99.8)
+    assert lat == pytest.approx(40.9)
+
+
+# --- haversine_distance -----------------------------------------------------
+
+def test_haversine_zero_distance():
+    assert haversine_distance(40.0, -100.0, 40.0, -100.0) == pytest.approx(0.0)
+
+
+def test_haversine_one_degree_latitude():
+    # One degree of latitude is ~111.19 km on a sphere of radius 6371 km.
+    d = haversine_distance(40.0, -100.0, 41.0, -100.0)
+    assert d == pytest.approx(111.19, abs=0.1)
+
+
+def test_haversine_known_city_pair():
+    # New York City to Los Angeles great-circle distance is ~3936 km.
+    d = haversine_distance(40.7128, -74.0060, 34.0522, -118.2437)
+    assert 3900.0 < d < 3970.0
+
+
+def test_haversine_is_symmetric():
+    a = haversine_distance(19.4326, -99.1332, 18.4655, -66.1057)
+    b = haversine_distance(18.4655, -66.1057, 19.4326, -99.1332)
+    assert a == pytest.approx(b)
+
+
+# --- clip_array_to_bounds ---------------------------------------------------
+
+def _grid(rows=10, cols=10):
+    return np.arange(rows * cols, dtype=np.float32).reshape(rows, cols)
+
+
+def test_clip_interior_window():
+    array = _grid(10, 10)
+    array_bounds = bounds_to_bbox(-100.0, 40.0, -99.0, 41.0)
+    clip_bounds = bounds_to_bbox(-99.5, 40.3, -99.2, 40.7)
+    clipped = clip_array_to_bounds(array, array_bounds, clip_bounds)
+    # lon 0.5..0.8 -> cols 5..8 ; lat (top-down) 0.3..0.7 -> rows 3..7
+    assert clipped.shape == (4, 3)
+    np.testing.assert_array_equal(clipped, array[3:7, 5:8])
+
+
+def test_clip_clamps_to_array_extent():
+    array = _grid(10, 10)
+    array_bounds = bounds_to_bbox(-100.0, 40.0, -99.0, 41.0)
+    # clip request larger than the array on every side
+    clip_bounds = bounds_to_bbox(-200.0, 0.0, 0.0, 90.0)
+    clipped = clip_array_to_bounds(array, array_bounds, clip_bounds)
+    assert clipped.shape == array.shape
+
+
+def test_clip_non_overlapping_returns_empty():
+    array = _grid(10, 10)
+    array_bounds = bounds_to_bbox(-100.0, 40.0, -99.0, 41.0)
+    clip_bounds = bounds_to_bbox(10.0, 10.0, 11.0, 11.0)
+    clipped = clip_array_to_bounds(array, array_bounds, clip_bounds)
+    assert clipped.size == 0

--- a/tests/test_map_export.py
+++ b/tests/test_map_export.py
@@ -6,7 +6,14 @@ from src.analysis.map_export import (
     build_ndvi_legend_html,
     export_ndvi_map,
     NDVI_LEGEND,
+    NODATA_COLOR,
 )
+
+
+def test_ndvi_to_color_nan_is_nodata():
+    # No-data pixels must not be colored as dense vegetation.
+    assert ndvi_to_color(float("nan")) == NODATA_COLOR
+    assert ndvi_to_color(np.float32("nan")) == NODATA_COLOR
 
 
 def test_ndvi_to_color_water():


### PR DESCRIPTION
## What & why

While adding test coverage for `src/utils/geo_utils.py` — the only logic module without a `test_*.py` — a test surfaced a real correctness bug, so this PR fixes it and lands the coverage.

### 1. Bug fix: `clip_array_to_bounds` off-by-one

The function converted geographic offsets to pixel indices with `int(...)`. Because IEEE-754 stores a mathematically-integer index like `0.8 * 10` as `7.999999999`, `int()` truncated it to `7`, shifting the clip window by a **whole pixel in both axes** — so the wrong region was analysed.

Repro (now a test): clipping a 10×10 grid spanning `[-100,-99]×[40,41]` to `[-99.5,-99.2]×[40.3,40.7]` should yield a `(4, 3)` window but returned `(5, 2)`.

Fix: snap to the nearest pixel within a tiny tolerance (`_PIXEL_EPS = 1e-9`, far below one pixel) before truncating.

### 2. New tests: `tests/test_geo_utils.py`

Covers `haversine_distance` (zero, 1°-latitude ≈ 111.19 km, NYC↔LA ≈ 3936 km, symmetry), `bounds_to_bbox` (happy path + both `ValueError` raises + degenerate extent), `pixel_to_coords` (affine), and `clip_array_to_bounds` (interior / clamped / non-overlapping).

### 3. Small fix: `ndvi_to_color(NaN)`

NaN compares `False` against every legend breakpoint, so no-data pixels fell through to the **dense-canopy** colour. Added an explicit NaN → `NODATA_COLOR` guard (consistent with how `export_ndvi_map` already handles NaN) plus a test.

## Verification

Full suite green locally: `54 passed`. No new dependencies; touches only `analysis`/`utils` + tests.